### PR TITLE
added systemd unit file

### DIFF
--- a/unifi-proxy.service
+++ b/unifi-proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=unifi-proxy discovery
+Documentation=https://github.com/bahamas10/unifi-proxy
+After=network.target
+
+[Service]
+Environment=NODE_PORT=10001
+Type=simple
+User=nobody
+ExecStart=/usr/bin/node /opt/unifi-proxy/server.js /opt/unifi-proxy/packet.json
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
pre-requisites:
- make sure you install (clone) to `/opt/unifi-proxy`
- make sure you have `/opt/unifi-proxy/packet.json`

unit file installation:
```
cp -a unifi-proxy.service /etc/systemd/system/unifi-proxy.service
systemctl daemon-reload
systemctl enable unifi-proxy
systemctl start unifi-proxy
```
